### PR TITLE
feat(update): extend 'update' command to support OSS deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,9 @@ require (
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.8.0
 	github.com/theckman/yacspin v0.13.12
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+	golang.org/x/mod v0.7.0
 	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c
 	google.golang.org/grpc v1.50.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
@@ -26,6 +27,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
@@ -36,6 +38,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/modproxy/proxy.go
+++ b/internal/modproxy/proxy.go
@@ -1,0 +1,177 @@
+package modproxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
+)
+
+// Proxy wraps a Getter and a list of proxy URLs to provide the required module proxy operations
+type Proxy struct {
+	g       Getter
+	proxies []string
+}
+
+// New returns a Proxy instance that will use g to execute HTTP requests against the module proxies
+// in urls.
+func New(g Getter, urls ...string) Proxy {
+	if len(urls) == 0 {
+		urls = getModProxies()
+	}
+	return Proxy{
+		g:       g,
+		proxies: urls,
+	}
+}
+
+// NewFromEnv returns a Proxy instance that will use g to execute HTTP requests against the module proxies
+// configured in the system environment
+func NewFromEnv(g Getter) Proxy {
+	return New(g)
+}
+
+// GetCurrentVersion returns the highest known version of the specified module, as returned by list of
+// module proxies configured on p.
+func (p Proxy) GetCurrentVersion(mod string, includePrerelease bool) (string, error) {
+	versions, err := p.GetModuleVersions(mod)
+	if err != nil {
+		return "", err
+	}
+	latest := versions[0]
+	for _, v := range versions {
+		if semver.Compare(v, latest) > 0 && (semver.Prerelease(v) == "" || includePrerelease) {
+			latest = v
+		}
+	}
+	return latest, nil
+}
+
+// GetModuleVersions retrieve a list of module versions for the specified module by querying the list
+// of module proxies configured on p.
+func (p Proxy) GetModuleVersions(mod string) ([]string, error) {
+	for _, proxy := range p.proxies {
+		url := proxy + "/" + path.Join(mod, "@v/list")
+		resp, err := p.g.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching module versions from %s: %w", proxy, err)
+		}
+		defer func() {
+			if resp.Body != nil {
+				_ = resp.Body.Close()
+			}
+		}()
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// no error check here b/c we've already checked the error from Get() and the response status code
+			data, _ := io.ReadAll(resp.Body)
+			// the response is a plain text list of module versions delimited by newlines
+			// - see https://go.dev/ref/mod#goproxy-protocol
+			if len(data) == 0 {
+				// proceed to the next proxy, if present, if we got no data
+				continue
+			}
+			ss := strings.Split(string(data), "\n")
+			res := make([]string, len(ss))
+			for i, s := range ss {
+				res[i] = strings.TrimSpace(s)
+			}
+			return res, nil
+		case http.StatusNotFound, http.StatusGone:
+			// try the next proxy
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected response code (%s) from %s", resp.Status, proxy)
+		}
+	}
+	return nil, fmt.Errorf("no versions found for %s", mod)
+}
+
+// GetModFile retrieves the go.mod file for the specified module by querying the list of module proxies
+// configured on p.
+func (p Proxy) GetModFile(mod, version string) (*modfile.File, error) {
+	for _, proxy := range p.proxies {
+		u := proxy + "/" + path.Join(mod, "@v", semver.Canonical(version)+".mod")
+		resp, err := p.g.Get(u)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching module versions from %s: %w", u, err)
+		}
+		defer func() {
+			if resp.Body != nil {
+				_ = resp.Body.Close()
+			}
+		}()
+		switch resp.StatusCode {
+		case http.StatusOK:
+			data, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("error reading the module proxy respons from %s: %w", u, err)
+			}
+			f, err := modfile.ParseLax(mod+"@"+version+"/go.mod", data, nil)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing go.mod from %s: %w", u, err)
+			}
+			return f, nil
+		case http.StatusNotFound, http.StatusGone:
+			// try the next proxy
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected response code from %s: %s", u, resp.Status)
+		}
+	}
+	return nil, fmt.Errorf("the specified module was not found")
+}
+
+// Getter defines a type, such as http.Client, that can perform an HTTP GET request and return
+// the result.
+//
+// This interface is defined so that consumers and tests can provide potentially customized implementations,
+// but http.DefaultClient (or some other constructed http.Client instance) will likely be the most
+// common implementation used.
+type Getter interface {
+	Get(url string) (*http.Response, error)
+}
+
+// GetCurrentVersion returns the highest known version of the specified module, as returned by the
+// system's module proxy.
+func GetCurrentVersion(g Getter, mod string, includePrerelease bool) (string, error) {
+	p := NewFromEnv(g)
+	return p.GetCurrentVersion(mod, includePrerelease)
+}
+
+// GetModuleVersions uses the provided getter instance to retrieve a list of module versions for the
+// specified module by querying the system Go module proxy ($GOPROXY)
+func GetModuleVersions(g Getter, mod string) ([]string, error) {
+	p := NewFromEnv(g)
+	return p.GetModuleVersions(mod)
+}
+
+// GetModFile uses the provided getter instance to retrieve the go.mod file for the specified module
+// by querying the system Go module proxy ($GOPROXY)
+func GetModFile(g Getter, mod, version string) (*modfile.File, error) {
+	p := NewFromEnv(g)
+	return p.GetModFile(mod, version)
+}
+
+// getModProxies returns a list of Go module proxies by parsing the GOPROXY environment variable.  If
+// no proxy is set ($GOPROXY is unset or "") this function returns a single result containing the
+// Google public proxy.
+func getModProxies() []string {
+	ev := os.Getenv("GOPROXY")
+	if ev == "" {
+		return []string{"https://proxy.golang.org"}
+	}
+	var results []string
+	for _, s := range strings.Split(ev, ",") {
+		// not trying to deal with pulling go.mod directly from various VCSs for now
+		if s != "direct" {
+			results = append(results, s)
+		}
+	}
+	return results
+}

--- a/internal/modproxy/proxy.go
+++ b/internal/modproxy/proxy.go
@@ -162,15 +162,21 @@ func GetModFile(g Getter, mod, version string) (*modfile.File, error) {
 // no proxy is set ($GOPROXY is unset or "") this function returns a single result containing the
 // Google public proxy.
 func getModProxies() []string {
+	// $GOPROXY is expected to be a string containing 0 or more URLs or the string "direct" separated
+	// by ',' or '|'
+	// - see https://go.dev/ref/mod#environment-variables
 	ev := os.Getenv("GOPROXY")
 	if ev == "" {
 		return []string{"https://proxy.golang.org"}
 	}
+	// convert '|' to ',' so we only need 1 call to strings.Split() below
+	ev = strings.ReplaceAll(ev, "|", ",")
 	var results []string
 	for _, s := range strings.Split(ev, ",") {
 		// not trying to deal with pulling go.mod directly from various VCSs for now
 		if s != "direct" {
-			results = append(results, s)
+			// remove any trailing slash so that the paths can be treated homogeneously
+			results = append(results, strings.TrimSuffix(s, "/"))
 		}
 	}
 	return results

--- a/internal/modproxy/proxy_test.go
+++ b/internal/modproxy/proxy_test.go
@@ -1,0 +1,264 @@
+package modproxy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/mod/modfile"
+)
+
+type getterFunc func(string) (*http.Response, error)
+
+func (f getterFunc) Get(url string) (*http.Response, error) {
+	return f(url)
+}
+
+func TestListModuleVersions(t *testing.T) {
+	// hard code 2 module proxies so that the "first proxy returns 404" test will actually have a
+	// 2nd proxy to hit
+	testProxies := []string{"https://one", "https://two"}
+	type testCase struct {
+		name     string
+		p        Proxy
+		expected []string
+		checkErr func(*testing.T, error)
+	}
+	testErr := fmt.Errorf("oh no")
+	cases := []testCase{
+		{
+			name: "server returned an error",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return nil, testErr
+			}), testProxies...),
+			checkErr: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, testErr)
+			},
+		},
+		{
+			name: "valid response/valid results",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte("v0.1.0\nv0.2.0"))),
+				}, nil
+			}), testProxies...),
+			expected: []string{"v0.1.0", "v0.2.0"},
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "first proxy returns 404",
+			p: New(func() getterFunc {
+				n := 0
+				return getterFunc(func(string) (*http.Response, error) {
+					if n == 0 {
+						n++
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+						}, nil
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBuffer([]byte("v0.1.0\nv0.2.0"))),
+					}, nil
+				})
+			}(), testProxies...),
+			expected: []string{"v0.1.0", "v0.2.0"},
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+	}
+	t.Parallel()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.p.GetModuleVersions("github.com/foo/bar")
+			tc.checkErr(t, err)
+			assert.ElementsMatch(t, tc.expected, got)
+		})
+	}
+}
+
+func TestGetCurrentVersion(t *testing.T) {
+	type testCase struct {
+		name              string
+		p                 Proxy
+		includePrerelease bool
+		expected          string
+		checkErr          func(*testing.T, error)
+	}
+	cases := []testCase{
+		{
+			name: "no versions",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(""))),
+				}, nil
+			}), "https://proxy.golang.org"),
+			expected: "",
+			checkErr: func(t *testing.T, err error) {
+				assert.Error(t, err)
+			},
+		},
+		{
+			name: "only 1 version",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte("v0.1.0"))),
+				}, nil
+			}), "https://proxy.golang.org"),
+			expected: "v0.1.0",
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "multiple versions",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte("v0.1.0\nv1.0.0\nv1.0.1\nv1.10.0\nv1.2.0\nv1.20.0"))),
+				}, nil
+			}), "https://proxy.golang.org"),
+			expected: "v1.20.0",
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "multiple versions with prereleases",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte("v0.1.0\nv1.0.0\nv1.0.1\nv1.10.0\nv1.2.0\nv1.20.0\nv1.3.0-alpha"))),
+				}, nil
+			}), "https://proxy.golang.org"),
+			expected: "v1.20.0",
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "multiple versions with prerelease for vNext",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte("v0.1.0\nv1.0.0\nv1.0.1\nv1.10.0\nv1.2.0\nv1.20.0\nv1.21.0-rc1\nv1.3.0-alpha"))),
+				}, nil
+			}), "https://proxy.golang.org"),
+			expected: "v1.20.0",
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "multiple versions with prerelease for vNext when including prerelease",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte("v0.1.0\nv1.0.0\nv1.0.1\nv1.10.0\nv1.2.0\nv1.20.0\nv1.21.0-rc1\nv1.3.0-alpha"))),
+				}, nil
+			}), "https://proxy.golang.org"),
+			includePrerelease: true,
+			expected:          "v1.21.0-rc1",
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+	}
+	t.Parallel()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.p.GetCurrentVersion("github.com/foo/bar", tc.includePrerelease)
+			tc.checkErr(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestDownloadModFile(t *testing.T) {
+	const modContents = "module github.com/foo/bar\n\ngo 1.18"
+	// hard code 2 module proxies so that the "first proxy returns 404" test will actually have a
+	// 2nd proxy to hit
+	testProxies := []string{"https://one", "https://two"}
+	type testCase struct {
+		name     string
+		p        Proxy
+		expected string
+		checkErr func(*testing.T, error)
+	}
+	testErr := fmt.Errorf("oh no")
+	cases := []testCase{
+		{
+			name: "server returned an error",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{}, testErr
+			}), testProxies...),
+			checkErr: func(t *testing.T, err error) {
+				assert.True(t, errors.Is(err, testErr))
+			},
+		},
+		{
+			name: "valid response",
+			p: New(getterFunc(func(string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(modContents))),
+				}, nil
+			}), testProxies...),
+			expected: modContents,
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "first proxy returns 404",
+			p: New(func() getterFunc {
+				n := 0
+				return getterFunc(func(string) (*http.Response, error) {
+					if n == 0 {
+						n++
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+						}, nil
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBuffer([]byte(modContents))),
+					}, nil
+				})
+			}(), testProxies...),
+			expected: modContents,
+			checkErr: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+	}
+	t.Parallel()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.p.GetModFile("github.com/foo/bar", "v0.0.0")
+			tc.checkErr(t, err)
+
+			var mod *modfile.File
+			if err == nil {
+				mod, _ = modfile.ParseLax("github.com/foo/bar@v0.0.0/go.mod", []byte(tc.expected), nil)
+			}
+			assert.Equal(t, mod, got, "go.mod contents must match")
+		})
+	}
+}

--- a/scripts/processmod.sh
+++ b/scripts/processmod.sh
@@ -34,5 +34,5 @@ echo "Processing module at ${_PERSEUS_MODULE_PATH}"
 for t in `git tag --list 'v*' --sort=-v:refname`; do
     echo "   analyzing ${t} ..."
     git checkout -q ${t}
-    perseus update ${_PERSEUS_MODULE_PATH} --version ${t}
+    perseus update --path ${_PERSEUS_MODULE_PATH} --version ${t}
 done


### PR DESCRIPTION
This PR reworks the `perseus update` command to support reading module dependencies from either a local path *or* from the public module proxy/proxies.

It does include a breaking behavior change.  Where before `perseus update` took a single positional arg that contained the path to a module on disk, it now requires explicitly specifying whether it's processing a module on disk (`-p/--path`) or querying a module proxy (`-m/--module`).

Resolves #24 