### PR TITLE
Publish a service Docker container to GH Container Registry on release

### DIFF
--- a/.github/workflows/check-goreleaser.yml
+++ b/.github/workflows/check-goreleaser.yml
@@ -1,0 +1,25 @@
+name: Validate Goreleaser Config
+
+on:
+  pull_request:
+    paths:
+      - '.goreleaser.yml'
+
+jobs:
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+      -
+        name: Run 'goreleaser check'
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: check

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  perseus:
+  lint-test-and-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,14 +23,6 @@ jobs:
 
       - name: test
         run: go test -v -race ./...
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-
-      - name: perseus
+      - name: build
         run: go build .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:
@@ -22,6 +23,12 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,29 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+dockers:
+  - id: perseus-service
+    ids:
+      - perseus-cli
+    image_templates:
+      - "ghcr.io/crowdstrike/perseus:latest"
+      - "ghcr.io/crowdstrike/perseus:{{ .Version }}"
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.service
+    build_flag_templates:
+      - '--pull'
+      - '--label=org.opencontainers.image.created={{ .Date }}'
+      - '--label=org.opencontainers.image.name={{ .ProjectName }}'
+      - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
+      - '--label=org.opencontainers.image.version={{ .Version }}'
+      - '--label=org.openconatiners.image.licenses=MIT'
+      - '--label=org.opencontainers.image.source=https://github.com/CrowdStrike/perseus'
+      - >
+        --label=org.opencontainers.image.description=A Docker image to run a containerized Perseus server.
+        This image is built from a 'scratch' base image and runs "perseus server", exposing port 31138 from the container.
+        You must specify the following environment variables: DB_ADDR (the address of the Perseus database),
+        DB_USER (the login for the database) and DB_PASS (the login password for the database).
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,0 +1,4 @@
+FROM scratch
+COPY perseus /
+EXPOSE 31138
+ENTRYPOINT ["/perseus", "server"]

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,15 @@ PROJECT_BASE_DIR := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 # prepend the project-local bin/ folder to $PATH so that we find build-time tools there
 PATH := ${PROJECT_BASE_DIR}/bin:${PATH}
 
-TEST_OPTS ?= -race -v
+TEST_RACE ?= -race
+TEST_OPTS ?=
 
 .PHONY: all
 all: protos bin
 	$(info TODO)
+
+.PHONY: check
+check: lint check-goreleaser-config test
 
 .PHONY: protos
 protos: install-tools check-buf-install
@@ -16,7 +20,7 @@ protos: install-tools check-buf-install
 
 .PHONY: test
 test:
-	@go test ${TEST_OPTS} ./...
+	@go test ${TEST_OPTS} ${TEST_RACE} ./...
 
 BUILD_TIME_TOOLS =\
 	github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway\
@@ -52,6 +56,11 @@ lint-go: check-golangci-lint-install
 lint-protos: check-buf-install
 	$(info Linting Protobuf files ...)
 	@buf lint ./perseusapi
+
+.PHONY: check-goreleaser-config
+check-goreleaser-config:
+	$(info Validating goreleaser config ...)
+	@goreleaser check
 
 .PHONY: snapshot
 snapshot: check-goreleaser-install

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ lint-protos: check-buf-install
 
 .PHONY: snapshot
 snapshot: check-goreleaser-install
-	@goreleaser release --snapshot --rm-dist
+	@goreleaser release --snapshot --rm-dist --skip-publish
 
 .PHONY: check-buf-install
 check-buf-install:

--- a/debug.go
+++ b/debug.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"sync"
@@ -17,7 +18,8 @@ func debugLog(format string, args ...any) {
 		return
 	}
 	initLogOnce.Do(func() {
-		logger = log.New(os.Stdout, "[PERSEUS] ", log.LstdFlags|log.LUTC)
+		logger = log.New(os.Stdout, "[PERSEUS] ", log.LstdFlags|log.LUTC|log.Llongfile)
 	})
-	logger.Printf(format, args...)
+	// skip 2 stack frames so that the logs report the code that called into this function
+	logger.Output(2, fmt.Sprintf(format, args...))
 }

--- a/debug.go
+++ b/debug.go
@@ -21,5 +21,5 @@ func debugLog(format string, args ...any) {
 		logger = log.New(os.Stdout, "[PERSEUS] ", log.LstdFlags|log.LUTC|log.Llongfile)
 	})
 	// skip 2 stack frames so that the logs report the code that called into this function
-	logger.Output(2, fmt.Sprintf(format, args...))
+	_ = logger.Output(2, fmt.Sprintf(format, args...))
 }

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	rootCommand.PersistentFlags().BoolVarP(&debugMode, "debug", "x", false, "enable verbose logging")
+	rootCommand.PersistentFlags().BoolVarP(&debugMode, "debug", "x", os.Getenv("LOG_VERBOSITY") == "debug", "enable verbose logging")
 
 	rootCommand.AddCommand(server.CreateServerCommand(debugLog))
 	rootCommand.AddCommand(createUpdateCommand())


### PR DESCRIPTION
This PR introduces an additional step to the release process that will build and publish a Docker image containing the Perseus server.  The image is based on a `scratch` base and contains a Linux build of the binary, with the container entry point set to `perseus server`.

The release will publish to `ghcr.io/crowdstrike/perseus` and push both `latest` and a tag with the newly tagged release version.