### PR TITLE
feat: Publish to GHCR on release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: lint
         uses: golangci/golangci-lint-action@v3.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,32 +27,29 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-# DEVNOTE - dylan.bourque (2023-02-07)
-#   commented this out until we're able to publish public container images so that it won't block other
-#   release CI tasks
-# dockers:
-#   - id: perseus-service
-#     ids:
-#       - perseus-cli
-#     image_templates:
-#       - "ghcr.io/crowdstrike/perseus:latest"
-#       - "ghcr.io/crowdstrike/perseus:{{ .Version }}"
-#     goos: linux
-#     goarch: amd64
-#     dockerfile: Dockerfile.service
-#     build_flag_templates:
-#       - '--pull'
-#       - '--label=org.opencontainers.image.created={{ .Date }}'
-#       - '--label=org.opencontainers.image.name={{ .ProjectName }}'
-#       - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
-#       - '--label=org.opencontainers.image.version={{ .Version }}'
-#       - '--label=org.openconatiners.image.licenses=MIT'
-#       - '--label=org.opencontainers.image.source=https://github.com/CrowdStrike/perseus'
-#       - >
-#         --label=org.opencontainers.image.description=A Docker image to run a containerized Perseus server.
-#         This image is built from a 'scratch' base image and runs "perseus server", exposing port 31138 from the container.
-#         You must specify the following environment variables: DB_ADDR (the address of the Perseus database),
-#         DB_USER (the login for the database) and DB_PASS (the login password for the database).
+dockers:
+  - id: perseus-service
+    ids:
+      - perseus-cli
+    image_templates:
+      - "ghcr.io/crowdstrike/perseus:latest"
+      - "ghcr.io/crowdstrike/perseus:{{ .Version }}"
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.service
+    build_flag_templates:
+      - '--pull'
+      - '--label=org.opencontainers.image.created={{ .Date }}'
+      - '--label=org.opencontainers.image.name={{ .ProjectName }}'
+      - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
+      - '--label=org.opencontainers.image.version={{ .Version }}'
+      - '--label=org.openconatiners.image.licenses=MIT'
+      - '--label=org.opencontainers.image.source=https://github.com/CrowdStrike/perseus'
+      - >
+        --label=org.opencontainers.image.description=A Docker image to run a containerized Perseus server.
+        This image is built from a 'scratch' base image and runs "perseus server", exposing port 31138 from the container.
+        You must specify the following environment variables: DB_ADDR (the address of the Perseus database),
+        DB_USER (the login for the database) and DB_PASS (the login password for the database).
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Enables building and publishing a `ghcr.io/crowdstrike/perseus` Docker container image to GHCR when a new release is tagged.