### PR TITLE
Address several UX issues

### DIFF
--- a/client_config.go
+++ b/client_config.go
@@ -4,21 +4,33 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	"github.com/CrowdStrike/perseus/perseusapi"
 )
 
+// package variables to hold CLI flag values
+var (
+	formatAsJSON, formatAsList, formatAsDotGraph bool
+	formatTemplate                               string
+	maxDepth                                     int
+	disableTLS                                   bool
+)
+
 // clientConfig defines the runtime options for the "client" CLI commands
 type clientConfig struct {
 	// the TCP host/port of the Perseus server
 	serverAddr string
+	// do not use TLS when connecting if true
+	disableTLS bool
 }
 
 // clientOption defines a functional option that configures a particular "client" CLI runtime option
@@ -32,12 +44,26 @@ func withServerAddress(addr string) clientOption {
 	}
 }
 
+// withInsecureDial disables TLS when connecting to the server
+func withInsecureDial() clientOption {
+	return func(conf *clientConfig) error {
+		conf.disableTLS = true
+		return nil
+	}
+}
+
 // readClientConfig scans the process environment vars and returns a list of 0 or more config options
 func readClientConfigEnv() []clientOption {
 	var opts []clientOption
 
 	if addr := os.Getenv("PERSEUS_SERVER_ADDR"); addr != "" {
 		opts = append(opts, withServerAddress(addr))
+	}
+	if s := os.Getenv("PERSEUS_SERVER_NO_TLS"); s != "" {
+		val, err := strconv.ParseBool(s)
+		if val && err != nil {
+			opts = append(opts, withInsecureDial())
+		}
 	}
 
 	return opts
@@ -50,6 +76,9 @@ func readClientConfigFlags(fset *pflag.FlagSet) []clientOption {
 
 	if addr, err := fset.GetString("server-addr"); err == nil && addr != "" {
 		opts = append(opts, withServerAddress(addr))
+	}
+	if v, err := fset.GetBool("insecure"); err == nil && v {
+		opts = append(opts, withInsecureDial())
 	}
 
 	return opts
@@ -75,10 +104,14 @@ func (conf *clientConfig) dialServer() (client perseusapi.PerseusServiceClient, 
 	// setup gRPC connection options and connect
 	dialOpts := []grpc.DialOption{
 		grpc.WithBlock(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()), // TODO: support TLS
 	}
-	debugLog("connecting to Perseus server", "addr", conf.serverAddr)
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	if conf.disableTLS {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(nil)))
+	}
+	debugLog("connecting to Perseus server", "addr", conf.serverAddr, "useTLS", !conf.disableTLS)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	conn, err := grpc.DialContext(ctx, conf.serverAddr, dialOpts...)
 	if err != nil {

--- a/debug.go
+++ b/debug.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -51,10 +52,13 @@ func debugLog(msg string, kvs ...any) {
 		return
 	}
 
-	nattrs := len(kvs) / 2
-	attrs := make([]slog.Attr, nattrs)
-	for i := 0; i < nattrs; i += 2 {
-		attrs[i] = slog.Any(kvs[i].(string), kvs[i+1])
+	attrs := make([]slog.Attr, 0, len(kvs)/2)
+	for i := 0; i < len(kvs); i += 2 {
+		k, ok := kvs[i].(string)
+		if !ok {
+			k = fmt.Sprintf("%v", kvs[i])
+		}
+		attrs = append(attrs, slog.Any(k, kvs[i+1]))
 	}
 	logger.LogAttrsDepth(1, slog.LevelDebug, msg, attrs...)
 }

--- a/internal/server/web/js/data.js
+++ b/internal/server/web/js/data.js
@@ -10,12 +10,12 @@ const getModuleVersions = (module) => {
   return fetch(
     `${apiBase}/module-versions?module_name=${module}&version_option=all`
     )
-    .then((data) => data.json())
-    .then((resp) => {
+    .then((resp) => resp.json())
+    .then((data) => {
       // API response structure is 1-element array of modules
       //  {"modules":[{"name": "github.com/example/foo", "versions":["v0.1.0", "v0.2.0", ...]}]}
       //
-      return resp.modules[0].versions
+      return data.modules[0].versions
     });
 };
 
@@ -23,8 +23,8 @@ const getModuleDeps = (module, version, direction) => {
   return fetch(
     `${apiBase}/modules-dependencies?module_name=${module}&version=${version}&direction=${direction}`
   )
-    .then((data) => data.json())
-    .then((resp) => {
+    .then((resp) => resp.json())
+    .then((data) => {
       // API response structure is an array of modules that are direct dependencies/dependants of
       // the current module, each with a single version
       //  {"modules":[{"name": "github.com/example/foo", "versions":["v0.1.0"]}, ...]}
@@ -34,7 +34,7 @@ const getModuleDeps = (module, version, direction) => {
       let out = { nodes: [], links: [] };
       out.nodes.push({ id: fqmn, label: fqmn, level: 0 });
 
-      resp.modules.forEach((mod) => {
+      data.modules.forEach((mod) => {
         const name = `${mod.name}@${mod.versions[0]}`;
         out.nodes.push({ id: name, label: name, level: 1 });
         out.links.push({ source: fqmn, target: name });

--- a/internal/server/web/js/data.js
+++ b/internal/server/web/js/data.js
@@ -9,9 +9,14 @@ const listModules = async () => {
 const getModuleVersions = (module) => {
   return fetch(
     `${apiBase}/module-versions?module_name=${module}&version_option=all`
-  )
+    )
     .then((data) => data.json())
-    .then((resp) => resp.versions);
+    .then((resp) => {
+      // API response structure is 1-element array of modules
+      //  {"modules":[{"name": "github.com/example/foo", "versions":["v0.1.0", "v0.2.0", ...]}]}
+      //
+      return resp.modules[0].versions
+    });
 };
 
 const getModuleDeps = (module, version, direction) => {
@@ -20,6 +25,10 @@ const getModuleDeps = (module, version, direction) => {
   )
     .then((data) => data.json())
     .then((resp) => {
+      // API response structure is an array of modules that are direct dependencies/dependants of
+      // the current module, each with a single version
+      //  {"modules":[{"name": "github.com/example/foo", "versions":["v0.1.0"]}, ...]}
+      //
       const fqmn = `${module}@${version}`;
 
       let out = { nodes: [], links: [] };

--- a/query.go
+++ b/query.go
@@ -21,13 +21,6 @@ import (
 	"github.com/CrowdStrike/perseus/perseusapi"
 )
 
-// package variables to hold CLI flag values
-var (
-	formatAsJSON, formatAsList, formatAsDotGraph bool
-	formatTemplate                               string
-	maxDepth                                     int
-)
-
 const (
 	goTemplateArgUsage = `provides a Go text template to format the output.
 Each result is an instance of the following struct:
@@ -71,6 +64,7 @@ func createQueryCommand() *cobra.Command {
 	fset.BoolVar(&formatAsDotGraph, "dot", false, "specifies that the output should be a DOT directed graph (not supported for list-modules or list-module-versions)")
 	fset.StringVarP(&formatTemplate, "format", "f", "", goTemplateArgUsage)
 	fset.IntVar(&maxDepth, "max-depth", 4, "specifies the maximum number of levels to be returned")
+	fset.BoolVar(&disableTLS, "insecure", false, "do not use TLS when connecting to the Perseus server")
 
 	listModulesCmd := cobra.Command{
 		Use:          "list-modules [pattern]",

--- a/update.go
+++ b/update.go
@@ -44,6 +44,7 @@ func createUpdateCommand() *cobra.Command {
 	fset.BoolVar(&includePrerelease, "prerelease", false, "if specified, include pre-release tags when processing the module")
 	fset.StringP("path", "p", "", "specifies the local path on disk to a Go module repository")
 	fset.StringP("module", "m", "", "specifies the module path of a public Go module")
+	fset.BoolVar(&disableTLS, "insecure", false, "do not use TLS when connecting to the Perseus server")
 
 	return &cmd
 }


### PR DESCRIPTION
This PR addresses several issues found  while using Perseus internally at CrowdStrike.

- The client CLI was not able to connect to a remove server using TLS.
  - This was addressed by defaulting to using TLS when dialing and adding a new `--insecure` flag to the `query` and `update` commands to manually disable TLS where necessary (such as when doing local debugging)
- The module details page in the web UI did not show any data.
  - There was a change to the structure of the response from the `.../module-versions` endpoint and the UI was not updated
- `query list-modules` would fail if a module has no stable versions in the database
  - Added logic to attempt to find a pre-release if no stable release exists
