### PR TITLE
feat: Add find path command

### DIFF
--- a/findpath.go
+++ b/findpath.go
@@ -130,10 +130,10 @@ func printTreeTo(w io.Writer, paths [][]module.Version) {
 	for _, p := range paths {
 		for indent, pp := range p {
 			if indent > 0 {
-				io.WriteString(w, fmt.Sprintf("%s-> ", strings.Repeat(" ", 3*(indent-1))))
+				_, _ = io.WriteString(w, fmt.Sprintf("%s-> ", strings.Repeat(" ", 3*(indent-1))))
 			}
-			io.WriteString(w, pp.String())
-			io.WriteString(w, "\n")
+			_, _ = io.WriteString(w, pp.String())
+			_, _ = io.WriteString(w, "\n")
 		}
 	}
 }
@@ -144,9 +144,9 @@ func printTreeTo(w io.Writer, paths [][]module.Version) {
 func printJSONLinesTo(w io.Writer, paths [][]module.Version) {
 	for _, p := range paths {
 		for _, pp := range p {
-			io.WriteString(w, fmt.Sprintf("{%q:", pp))
+			_, _ = io.WriteString(w, fmt.Sprintf("{%q:", pp))
 		}
-		io.WriteString(w, fmt.Sprintf("{}%s\n", strings.Repeat("}", len(p))))
+		_, _ = io.WriteString(w, fmt.Sprintf("{}%s\n", strings.Repeat("}", len(p))))
 	}
 }
 

--- a/findpath.go
+++ b/findpath.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/mod/module"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/CrowdStrike/perseus/perseusapi"
+)
+
+const findPathsExampleUsage = `# find any path between the latest version of github.com/example/foo and any version of gRPC
+# and output the result as a tree
+perseus find-paths github.com/example/foo google.golang.org/grpc
+
+# same, but output JSON
+perseus find-paths github.com/example/foo google.golang.org/grpc --json
+
+# find all paths between the latest version of github.com/example/foo and v1.43.0 of gRPC
+# and output the result as a tree
+perseus find-paths github.com/example/foo google.golang.org/grpc@v1.43.0 --all
+
+# find all paths between v1.0.0 of github.com/example/foo and any version of gRPC
+# and output the results as line-delimited JSON
+perseus find-paths github.com/example/foo@v1.0.0 google.golang.org/grpc --all --json`
+
+func createFindPathsCommand() *cobra.Command {
+	cmd := cobra.Command{
+		Use:          "find-paths from_module[@version] to_module[@version]",
+		Example:      findPathsExampleUsage,
+		Aliases:      []string{"fp", "why"},
+		Short:        "Queries the Perseus graph to find dependency path(s) between modules",
+		RunE:         runFindPathsCommand,
+		SilenceUsage: true,
+	}
+	fset := cmd.Flags()
+	fset.String("server-addr", os.Getenv("PERSEUS_SERVER_ADDR"), "the TCP host and port of the Perseus server (default is $PERSEUS_SERVER_ADDR environment variable)")
+	fset.BoolVar(&formatAsJSON, "json", false, "specifies that the output should be formatted as line-delimited JSON")
+	fset.Bool("all", false, "Return all paths between the two modules")
+	fset.IntVar(&maxDepth, "max-depth", 4, "specifies the maximum number of levels to be returned")
+	fset.BoolVar(&disableTLS, "insecure", false, "do not use TLS when connecting to the Perseus server")
+
+	return &cmd
+}
+
+func runFindPathsCommand(cmd *cobra.Command, args []string) (err error) {
+	conf, err := parseSharedQueryOpts(cmd, args)
+	if err != nil {
+		return err
+	}
+	switch len(args) {
+	case 0, 1:
+		return fmt.Errorf("The 'from' and 'to' modules are required")
+	case 2:
+		break
+	default:
+		return fmt.Errorf("Only 2 positional arguments, the 'from' and 'to' modules, are supported")
+	}
+
+	updateSpinner, stopSpinner := startSpinner()
+	defer stopSpinner()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	updateSpinner("connecting to the server at " + conf.serverAddr)
+	ps, err := conf.dialServer()
+	if err != nil {
+		return err
+	}
+
+	// validate the 'from' and 'to' modules, defaulting to the highest known release for 'from'
+	// if no version is specified
+	from, err := parseModuleArg(ctx, ps, args[0], true, updateSpinner)
+	if err != nil {
+		return err
+	}
+	to, err := parseModuleArg(ctx, ps, args[1], false, updateSpinner)
+	if err != nil {
+		return err
+	}
+
+	updateSpinner("Determining path(s) from " + from.String() + " to " + to.String())
+	var (
+		showAll, _ = cmd.Flags().GetBool("all")
+		paths      = [][]module.Version{}
+		pf         = newPathFinder(ps, maxDepth, updateSpinner)
+	)
+	// write the results on the way out
+	defer func() {
+		stopSpinner()
+		if err != nil {
+			return
+		}
+		if formatAsJSON {
+			printJSONLinesTo(os.Stdout, paths)
+		} else {
+			printTreeTo(os.Stdout, paths)
+		}
+	}()
+	for p := range pf.findPathsBetween(ctx, from, to) {
+		if p.err != nil {
+			if status.Code(p.err) == codes.Canceled || errors.Is(p.err, context.Canceled) {
+				// context cancellation is not a failure
+				return nil
+			}
+			return p.err
+		}
+
+		updateSpinner("adding path")
+		paths = append(paths, p.path)
+		if !showAll {
+			cancel()
+		}
+	}
+
+	return nil
+}
+
+// printTreeTo writes the provided list of dependency paths to w as a nested textual tree.  Each level
+// of the tree is indented and prefixed with "-> ".
+func printTreeTo(w io.Writer, paths [][]module.Version) {
+	for _, p := range paths {
+		for indent, pp := range p {
+			if indent > 0 {
+				io.WriteString(w, fmt.Sprintf("%s-> ", strings.Repeat(" ", 3*(indent-1))))
+			}
+			io.WriteString(w, pp.String())
+			io.WriteString(w, "\n")
+		}
+	}
+}
+
+// printJSONLinesTo writes the provided list of dependency paths to w as a series of line-delimited
+// JSON objects.  The JSON is structured such that each level has exactly 1 key, the name and version
+// of a module, with the value of that key being the remainder of the path.
+func printJSONLinesTo(w io.Writer, paths [][]module.Version) {
+	for _, p := range paths {
+		for _, pp := range p {
+			io.WriteString(w, fmt.Sprintf("{%q:", pp))
+		}
+		io.WriteString(w, fmt.Sprintf("{}%s\n", strings.Repeat("}", len(p))))
+	}
+}
+
+// parseModuleArg parses the provided string as a Go module path, optionally with a version, and returns
+// the parsed result.  If no version is specified, the highest known version is used.
+func parseModuleArg(ctx context.Context, c perseusapi.PerseusServiceClient, s string, findLatest bool, status func(string)) (module.Version, error) {
+	defer status("")
+	var m module.Version
+	toks := strings.Split(s, "@")
+	switch len(toks) {
+	case 1:
+		m.Path = toks[0]
+	case 2:
+		m.Path = toks[0]
+		m.Version = toks[1]
+	default:
+		return module.Version{}, fmt.Errorf("Invalid 'from' module path/version %q", s)
+	}
+	if err := module.CheckPath(m.Path); err != nil {
+		return module.Version{}, fmt.Errorf("The specified module name %q is invalid: %w", m, err)
+	}
+	if m.Version == "" && findLatest {
+		status("determining current version for " + m.String())
+		v, err := lookupLatestModuleVersion(ctx, c, m.Path)
+		if err != nil {
+			return module.Version{}, fmt.Errorf("Unable to determine the current version for %q: %w", m.Path, err)
+		}
+		m.Version = v
+	}
+	return m, nil
+}

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -149,7 +149,7 @@ func (p *PostgresClient) SaveModuleDependencies(ctx context.Context, mod Version
 		}
 		cmd = cmd.Values(versionIDs[0], vids[0])
 	}
-	sql, args, err := cmd.Suffix("ON CONFLICT (dependent_id, dependee_id) DO NOTHING").ToSql()
+	sql, args, err := cmd.Suffix("ON CONFLICT (dependent_id, dependee_id) DO UPDATE SET dependent_id = EXCLUDED.dependent_id").ToSql()
 	p.log("upsert module dependencies", "sql", sql, "args", args, "err", err)
 	if err != nil {
 		return fmt.Errorf("error constructing SQL query: %w", err)

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 	rootCommand.AddCommand(server.CreateServerCommand(debugLog))
 	rootCommand.AddCommand(createUpdateCommand())
 	rootCommand.AddCommand(createQueryCommand())
+	rootCommand.AddCommand(createFindPathsCommand())
 	rootCommand.AddCommand(versionCommand)
 
 	if err := rootCommand.Execute(); err != nil {

--- a/pathfinder.go
+++ b/pathfinder.go
@@ -69,7 +69,7 @@ func (pf *pathFinder) findPathsBetween(ctx context.Context, from, to module.Vers
 // and to.  If a dependency is found, a result is produced to rc.
 func (pf *pathFinder) xxx(ctx context.Context, chain []module.Version, to module.Version, depth int, rc chan pathFinderResult) {
 	// grab the semaphore b/c unbounded concurrency is :(
-	_ = <-pf.sem
+	<-pf.sem
 	defer func() { pf.sem <- struct{}{} }()
 
 	select {

--- a/pathfinder.go
+++ b/pathfinder.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	"golang.org/x/mod/module"
+
+	"github.com/CrowdStrike/perseus/perseusapi"
+)
+
+// newPathFinder initializes and returns a new [pathFinder] instance using the provided Perseus
+// client, maximum depth, and status callback.
+func newPathFinder(c perseusapi.PerseusServiceClient, maxDepth int, status func(string)) pathFinder {
+	return pathFinder{
+		c:        c,
+		maxDepth: maxDepth,
+		status:   status,
+	}
+}
+
+// pathFinder queries the Perseus database to contruct dependency paths of up to maxDepth steps between
+// two modules.
+type pathFinder struct {
+	c        perseusapi.PerseusServiceClient
+	status   func(string)
+	maxDepth int
+
+	sem chan struct{}
+	wg  *sync.WaitGroup
+}
+
+// pathFinderResult defines the result items produced by [pathFinder.findPathsBetween].  Each result
+// contains either a slice of [module.Version] instances representing a path between the specified modules
+// or an error.
+type pathFinderResult struct {
+	path []module.Version
+	err  error
+}
+
+// findPathsBetween repeatedly queries the Perseus server to find one or more dependency paths between
+// the two specified modules.
+func (pf *pathFinder) findPathsBetween(ctx context.Context, from, to module.Version) chan pathFinderResult {
+	// semaphore to limit concurrency to the number of available CPUs
+	n := runtime.NumCPU()
+	pf.sem = make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		pf.sem <- struct{}{}
+	}
+	// wait group to monitor outstanding async tasks
+	pf.wg = &sync.WaitGroup{}
+
+	results := make(chan pathFinderResult)
+	pf.wg.Add(1)
+	go func() {
+		defer func() {
+			pf.wg.Done()
+			pf.wg.Wait()
+			close(results)
+			close(pf.sem)
+		}()
+		pf.xxx(ctx, []module.Version{from}, to, 1, results)
+	}()
+	return results
+}
+
+// xxx recursively queries the Perseus graph searching for dependencies between the last element of chain
+// and to.  If a dependency is found, a result is produced to rc.
+func (pf *pathFinder) xxx(ctx context.Context, chain []module.Version, to module.Version, depth int, rc chan pathFinderResult) {
+	// grab the semaphore b/c unbounded concurrency is :(
+	_ = <-pf.sem
+	defer func() { pf.sem <- struct{}{} }()
+
+	select {
+	case <-ctx.Done():
+		rc <- pathFinderResult{err: ctx.Err()}
+		return
+	default:
+		from := chain[len(chain)-1]
+		// query the graph for direct dependencies of from
+		deps, err := walkDependencies(ctx, pf.c, from, perseusapi.DependencyDirection_dependencies, 1, 1, pf.status)
+		if err != nil {
+			rc <- pathFinderResult{err: err}
+			return
+		}
+		children := make([]module.Version, 0, len(deps.Deps))
+		for _, d := range deps.Deps {
+			select {
+			case <-ctx.Done():
+				rc <- pathFinderResult{err: ctx.Err()}
+				return
+			default:
+				if d.Module.Path == to.Path && (to.Version == "" || d.Module.Version == to.Version) {
+					debugLog("found path", "chain", chain, "to", d.Module)
+					// data sharing == bad
+					cc := make([]module.Version, len(chain))
+					copy(cc, chain)
+					rc <- pathFinderResult{path: append(cc, d.Module)}
+				}
+				children = append(children, d.Module)
+			}
+		}
+		// recurse down the graph if we haven't hit max yet
+		if depth <= pf.maxDepth {
+			for _, c := range children {
+				pf.wg.Add(1)
+				go func(c module.Version) {
+					defer pf.wg.Done()
+					// data sharing == bad
+					cc := make([]module.Version, len(chain))
+					copy(cc, chain)
+					pf.xxx(ctx, append(cc, c), to, depth+1, rc)
+				}(c)
+			}
+		}
+	}
+}

--- a/query.go
+++ b/query.go
@@ -90,7 +90,7 @@ func createQueryCommand() *cobra.Command {
 
 	descendantsCmd := cobra.Command{
 		Use:          "descendants module[@version]",
-		Aliases:      []string{"d", "dependants"},
+		Aliases:      []string{"d", "dependants", "dependents"},
 		Short:        "Outputs the list of modules that depend on the specified module",
 		RunE:         runQueryModuleGraphCmd,
 		SilenceUsage: true,
@@ -127,7 +127,7 @@ func runListModulesCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Only one of --json, --list, or --format may be specified")
 	}
 
-	updateSpinner, stopSpinner := startSpinner(" ")
+	updateSpinner, stopSpinner := startSpinner()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -166,7 +166,7 @@ func runListModuleVersionsCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Only one of --json, --list, or --format may be specified")
 	}
 
-	updateSpinner, stopSpinner := startSpinner(" ")
+	updateSpinner, stopSpinner := startSpinner()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -267,7 +267,7 @@ func runQueryModuleGraphCmd(cmd *cobra.Command, args []string) error {
 		dir = perseusapi.DependencyDirection_dependents
 	}
 
-	updateSpinner, stopSpinner := startSpinner(" ")
+	updateSpinner, stopSpinner := startSpinner()
 	tree, err := walkDependencies(ctx, ps, rootMod, dir, 1, maxDepth, updateSpinner)
 	if err != nil {
 		return err
@@ -658,7 +658,7 @@ func xor(vs ...bool) bool {
 
 // startSpinner initializes and starts a "spinner" for the console and returns
 // a function for updating the spinner's message and another to stop it.
-func startSpinner(msg string) (update func(string), done func()) {
+func startSpinner() (update func(string), done func()) {
 	update = func(string) {}
 	done = func() {}
 
@@ -667,7 +667,7 @@ func startSpinner(msg string) (update func(string), done func()) {
 		spinner, _ := yacspin.New(yacspin.Config{
 			CharSet:         yacspin.CharSets[11],
 			Frequency:       300 * time.Millisecond,
-			Message:         msg,
+			Message:         "",
 			Prefix:          "querying the graph ",
 			Suffix:          " ",
 			SuffixAutoColon: false,


### PR DESCRIPTION
This PR adds a new `perseus find-paths` command that outputs dependency paths between two specified modules.  The command can return all paths or only the first one found.  The output is either an indented textual tree or line-delimited JSON.

The command is intended to be an analog to `go mod why`.