### PR TITLE
chore(server): log health check errors

### DIFF
--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -26,13 +26,13 @@ func handleUX() http.Handler {
 
 // handleHealthz exposes an HTTP health check endpoint that responds with '200 OK' if the service is
 // healthy (can connect to the Perseus database) and '500 Internal Server Error' if not
-func handleHealthz(db store.Store, timeout time.Duration) http.Handler {
+func handleHealthz(db store.Store, timeout time.Duration, log Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), timeout)
 		defer cancel()
 		if err := db.Ping(ctx); err != nil {
+			log.Error(err, "Failing health check due to ping timeout", "timeout", timeout.String())
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "a connection to the database is unavailable")
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -163,7 +163,7 @@ func runServer(opts ...serverOption) error {
 	mux := http.NewServeMux()
 	mux.Handle("/", vt)
 	mux.Handle("/ui/", handleUX())
-	mux.Handle("/healthz", handleHealthz(db, conf.healthzTimeout))
+	mux.Handle("/healthz", handleHealthz(db, conf.healthzTimeout, log))
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)


### PR DESCRIPTION
add an error log when the database ping times out in the healthz/ handler to help with troubleshooting